### PR TITLE
Populate SQLALCHEMY_DATABASE_URI in config after KMS decryption

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -14,6 +14,8 @@ app = Flask('gogo', template_folder='../templates')
 app.config.from_object(os.environ['APP_SETTINGS'])
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
+app.config['SQLALCHEMY_DATABASE_URI'] = os.environ['DATABASE_URI']
+
 if app.config['BEHIND_PROXY']:
     app.wsgi_app = ProxyFix(app.wsgi_app)
 

--- a/src/config.py
+++ b/src/config.py
@@ -4,7 +4,6 @@ import os
 class Config(object):
     DEBUG = False
     CSRF_ENABLED = True
-    SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URI']
     TITLE = os.environ['TITLE']
 
     REDIRECT_URI = os.getenv('REDIRECT_URI')


### PR DESCRIPTION
When populating the config at the top of the makefile, we have not yet decrypted the Database URI from KMS (this happens in entrypoint).

This PR defers population of the SQLALCHEMY_DATABASE_URI env variable until after we've decrypted DATABASE_URI from DATABASE_URI_KMS