### PR TITLE
Remove testing framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ define DOCKER_RUN_ARGS
 -it
 endef
 
-.PHONY: run stop test venv
+.PHONY: run stop venv
 
 run: stop
 	@touch envfile
@@ -31,13 +31,6 @@ run: stop
 
 stop:
 	@docker rm -f $(DOCKER_IMAGE) > /dev/null 2>&1 || true
-
-test: stop
-	@touch envfile
-	@echo "Testing $(DOCKER_IMAGE)"
-	@docker run $$ARGS $$INTERACTIVE_ARGS --entrypoint sh \
-		"$(DOCKER_IMAGE)" \
-		-c "cd /app/src/ && PYTHONPATH=. pytest $$TEST_ARGS --cov"
 
 venv:
 	@echo "Creating and updating venv."

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -17,8 +17,7 @@ oauth2client==4.1.2
 psycopg2==2.7.3.1
 pyasn1==0.3.4
 pyasn1-modules==0.1.4
-pytest==3.2.3
-pytest-cov==2.5.1
+pyparsing==2.4.7
 python-dateutil==2.6.1
 requests==2.21.0
 rsa==4.7

--- a/src/gogo_test.py
+++ b/src/gogo_test.py
@@ -1,2 +1,0 @@
-def test_shortcut_redirect_view():
-    pass


### PR DESCRIPTION
We never built out the testing framework for gogo so let's just remove it for now. This also removes some dependencies from the gogo container that really should not be inside the docker container.