### PR TITLE
Fix `get_current_user` when `SKIP_AUTH` is used

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -80,7 +80,9 @@ def query_user(credentials, hosted_domain):
 
 
 def get_current_user():
-    if flask.current_app.config["USE_HEADER_AUTH"]:
+    if flask.current_app.config["SKIP_AUTH"]:
+        return "anonymous"
+    elif flask.current_app.config["USE_HEADER_AUTH"]:
         return get_current_user_from_header()
     elif flask.current_app.config["USE_GOOGLE_AUTH"]:
         return get_current_user_from_session()


### PR DESCRIPTION
When using `SKIP_AUTH` we tried to return `None` for the username, however, the DB schema expects the `owner` field to be not null. A quick way to resolve this is to just return an "anonymous" user/owner.