### PR TITLE
Support multiple placeholder url tokens

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5-stretch
+FROM python:3.7-bullseye
 
 # Env var to force update of the image. Increment for each time this is needed
 ENV CACHE_BUSTER_VAR=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN mkdir -p /app/ssl && cd /app/ssl && \
 
 # Set up gogo.
 ADD resources/requirements.txt /app/resources/requirements.txt
+RUN pip install setuptools==45
 RUN pip install -r /app/resources/requirements.txt && pip freeze
 
 ADD resources /app/resources/

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -25,5 +25,5 @@ s3transfer==0.1.11
 six==1.10.0
 SQLAlchemy==1.1.14
 uritemplate==3.0.0
-urllib3==1.26.5
+urllib3==1.24.3
 Werkzeug==0.15.3


### PR DESCRIPTION
Allows for having multiple tokens in secondary url.

For example:

go link: `go/foo/111/222`
secondary url: `https://example.com/abc/%s/def/%s`
result: `https://example.com/abc/111/def/222`

go link: `go/foo/111/222/333`
secondary url: `https://example.com/abc/%s/def/%s`
result: `https://example.com/abc/111/def/222/333`

go link: `go/foo/111`
secondary url: `https://example.com/abc/%s/def/%s`
result: `400 error` (more `%s` than tokens)