### PR TITLE
fix(ci): update the base docker image to python 3.12 and get the build working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-alpine3.19
 
-RUN apk add nginx jq openssl libpq-dev build-base
+RUN apk add nginx jq openssl libpq-dev build-base bash
 
 # Generate SSL certs.
 RUN mkdir -p /app/ssl && cd /app/ssl && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
-FROM python:3.7-bullseye
+FROM python:3.12-alpine3.19
 
-# Env var to force update of the image. Increment for each time this is needed
-ENV CACHE_BUSTER_VAR=1
-
-RUN apt-get update && \
-    apt-get install -y nginx jq && \
-    apt-get autoclean && \
-    rm -rf /var/lib/apt/cache
+RUN apk add nginx jq openssl libpq-dev build-base
 
 # Generate SSL certs.
 RUN mkdir -p /app/ssl && cd /app/ssl && \

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ run: stop docker_build
 		--hostname $(GOGO_HOST) \
 		--publish 80:80 \
 		--publish 443:443 \
+		--publish 5000:5000 \
 		--env CONFIG=DevelopmentConfig \
 		--env SKIP_AUTH=$(SKIP_AUTH) \
 		$(AUTH_HEADER_NAME_ENV) \

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -73,7 +73,7 @@ if [ -z "$AUTH_HEADER_NAME" ] && [ "$SKIP_AUTH" == "false" ]; then
     fi
 fi
 
-test -z "${DISABLE_NGINX}" && /usr/sbin/nginx -c /app/resources/nginx.conf -p /app/ &
+test -z "${DISABLE_NGINX}" && /usr/sbin/nginx -c /app/resources/nginx.conf &
 
 export APP_SETTINGS="config.${CONFIG}"
 

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -4,7 +4,7 @@ certifi==2017.7.27.1
 chardet==3.0.4
 click==6.7
 docutils==0.14
-Flask==1.0
+Flask==1.1.2
 Flask-SQLAlchemy==2.2
 google-api-python-client==1.6.3
 httplib2==0.19.0
@@ -13,7 +13,7 @@ itsdangerous==0.24
 Jinja2==2.11.3
 jmespath==0.9.3
 MarkupSafe==1.1.1
-oauth2client==4.1.2
+oauth2client==4.1.3
 psycopg2==2.9.10
 pyasn1==0.3.4
 pyasn1-modules==0.1.4
@@ -22,8 +22,8 @@ python-dateutil==2.6.1
 requests==2.21.0
 rsa==4.7
 s3transfer==0.1.11
-six==1.10.0
-SQLAlchemy==1.1.14
+six==1.16.0
+SQLAlchemy==1.4.54
 uritemplate==3.0.0
 urllib3==1.24.3
 Werkzeug==0.15.3

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -12,9 +12,9 @@ idna==2.6
 itsdangerous==0.24
 Jinja2==2.11.3
 jmespath==0.9.3
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 oauth2client==4.1.2
-psycopg2==2.7.3.1
+psycopg2==2.9.10
 pyasn1==0.3.4
 pyasn1-modules==0.1.4
 pyparsing==2.4.7


### PR DESCRIPTION
I tested this out locally using `make db` and `make run` to ensure the container comes up, Nginx works fine, and that the web UI works. I created links, and tested them and they work:

![image](https://github.com/user-attachments/assets/c10cce8e-8ba1-4a64-b14f-0f1dcf5e170d)
