### PR TITLE
chore(deps): change base image to alpine 3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine3.19
+FROM python:3.13-alpine3.20
 
 RUN apk add nginx jq openssl libpq-dev build-base bash
 


### PR DESCRIPTION
this will get us the latest nginx, which remediates the last CVE https://nvd.nist.gov/vuln/detail/CVE-2024-7347 we have.