### PR TITLE
fix(nginx): remove the x-forwarded-proto check

### DIFF
--- a/resources/nginx.conf
+++ b/resources/nginx.conf
@@ -49,7 +49,11 @@ http {
         '"event_name": "NGINX_LOG"'
     '}';
 
-    access_log /dev/stdout main;
+    map $status $loggable {
+      ~^[23]  0;
+      default 1;
+    }
+    access_log /dev/stderr main  if=$loggable;
     error_log  /dev/stderr;
 
     upstream app {
@@ -74,22 +78,6 @@ http {
         ssl_ecdh_curve            secp384r1;
         ssl_session_cache         shared:SSL:10m;
         ssl_session_tickets       off;
-
-        if ($scheme = http) {
-            set $redirect_to_https true;
-        }
-
-        if ($http_x_forwarded_proto = "http") {
-            set $redirect_to_https true;
-        }
-
-        if ($hostname = gogo-dev) {
-            set $redirect_to_https false;
-        }
-
-        if ($redirect_to_https = true) {
-            rewrite ^(.*) https://$host$1;
-        }
 
         # Web UI static content
         location /static {


### PR DESCRIPTION
that kind of check shouldn't be required, it should be optional and based on the users environments. this will let us run gogo behind istio.