### PR TITLE
fix: replace regex with path match for secondary links

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -53,7 +53,7 @@ app.add_url_rule(
 )
 app.add_url_rule("/_edit", view_func=gogo.EditShortcutView.as_view("edit_shortcut"))
 app.add_url_rule(
-    '/<regex(".+"):name>',
+    '/<path:name>',
     view_func=gogo.ShortcutRedirectView.as_view("shortcut_redirect"),
 )
 


### PR DESCRIPTION
When I upgraded to Flask V2, I didn't realize that the `regex` matcher seems to be gone, and now this is the only set of matchers that exist:

<img width="837" alt="image" src="https://github.com/user-attachments/assets/596700fc-f17d-46b6-9885-f32b51067be7">

Replacing the regex matcher with `path` seems to work though:

```
% curl localhost/git/fooobar -v 2>&1 | grep Location
< Location: https://github.com/Nextdoor/fooobar
% curl localhost/git -v 2>&1 | grep Location 
< Location: https://github.com/Nextdoor
```